### PR TITLE
Add support for MalDuino 3

### DIFF
--- a/boards/malduino3.json
+++ b/boards/malduino3.json
@@ -1,0 +1,55 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
+                "usb_vid": "0x16D0",
+                "usb_pid": "0x11A4"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m0plus",
+        "extra_flags": "-DARDUINO_GENERIC_RP2040 -DARDUINO_ARCH_RP2040",
+        "f_cpu": "133000000L",
+        "hwids": [
+            [
+                "0x16D0",
+                "0x11A4"
+            ],
+            [
+                "0x2E8A",
+                "0x00C0"
+            ]
+        ],
+        "mcu": "rp2040",
+        "variant": "generic"
+    },
+    "debug": {
+        "jlink_device": "RP2040_M0_0",
+        "openocd_target": "rp2040.cfg",
+        "svd_path": "rp2040.svd"
+    },
+    "frameworks": [
+        "arduino"
+    ],
+    "name": "MalDuino 3 (RP2040, 16MB)",
+    "upload": {
+        "maximum_ram_size": 262144,
+        "maximum_size": 16777216,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picotool",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "pico-debug",
+            "raspberrypi-swd",
+            "jlink",
+            "picotool"
+        ]
+    },
+    "url": "https://usbnova.com",
+    "vendor": "Maltronics"
+}

--- a/include/config.h
+++ b/include/config.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#define VERSION "1.2.2"
+#define VERSION "1.2.3-Custom"
 
 // ===== DEBUG Settings ===== //
 // #define ENABLE_DEBUG

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,13 +40,13 @@ build_flags =
     ${env.build_flags}
     -DUSE_TINYUSB
     -DLED_PIN=4
-    -DLED_DISABLED
+    -DLED_SCRIPTING_CONTROL_DISABLED
     -DLED_SIMPLE
     -DMULTI_SELECTOR
     -DSELECTOR_1=A7
     -DSELECTOR_2=A6
     -DSELECTOR_3=A3
-    -DSD_CS=1
+    -DSD_PIN_CS=1
     -I${platformio.packages_dir}/framework-arduino-samd-adafruit/libraries/Adafruit_TinyUSB_Arduino/src
     -I${platformio.packages_dir}/framework-arduino-samd-adafruit/libraries/SPI
     -I${platformio.packages_dir}/framework-arduino-samd-adafruit/libraries/Adafruit_ZeroDMA
@@ -88,6 +88,39 @@ lib_deps =
     adafruit/Adafruit SPIFlash @ ^4.0.0
     adafruit/Adafruit NeoPixel @ ^1.10.6
     adafruit/Adafruit Zero DMA Library @ ^1.1.3
+
+; ========================================
+; MalDuino 3 (RP2040 - Generic)
+; ========================================
+[env:malduino_rp2040]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = malduino3
+board_build.core = earlephilhower
+board_build.f_cpu = 133000000L
+board_build.filesystem_size = 15M
+src_filter = +<*> -<msc/format_spi.cpp> -<msc/msc_spi.cpp>
+build_flags = 
+    ${env.build_flags}
+    -DARDUINO_GENERIC_RP2040
+    -DUSE_TINYUSB
+    -DLED_PIN=1
+    -DLED_SCRIPTING_CONTROL_DISABLED
+    -DLED_SIMPLE
+    -DMULTI_SELECTOR
+    -DSELECTOR_1=27
+    -DSELECTOR_2=28
+    -DSELECTOR_3=29
+    -DUSE_CUSTOM_SPI_PINOUT
+    -DSD_PIN_MISO=8
+    -DSD_PIN_MOSI=11
+    -DSD_PIN_SCK=10
+    -DSD_PIN_CS=9
+    -DHID_SERIAL='"0100"'
+    -DHID_MANUFACTURER='"Maltronics"'
+    -DHID_PRODUCT='"MalDuino"'
+lib_deps = 
+    ${env.lib_deps}
+    adafruit/Adafruit SPIFlash @ ^4.0.0
 
 ; ========================================
 ; USB Nova MKII (RP2040 - Generic)

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -106,7 +106,7 @@ namespace cli {
 
             debuglnF("Done formatting!");
             debugln();
-        }).setDescription(" Fromat the internal memory.");
+        }).setDescription(" Format the internal memory.");
 
         // reset
         cli.addCmd("reset", [](cmd* c) {

--- a/src/duckparser/duckparser.cpp
+++ b/src/duckparser/duckparser.cpp
@@ -266,7 +266,7 @@ namespace duckparser {
                 ignore_delay = true;
             }
             // CHARDELAY/CHARACTER_DELAY (set delay between each character typed)
-            else if (compare(cmd->str, cmd->len, "CHARACTER_DELAY", CASE_SENSETIVE)) {
+            else if (compare(cmd->str, cmd->len, "CHARACTER_DELAY", CASE_SENSETIVE) || compare(cmd->str, cmd->len, "CHAR_DELAY", CASE_SENSETIVE)) {
                 character_delay = to_uint(line_str, line_str_len);
                 ignore_delay    = true;
             }
@@ -326,7 +326,7 @@ namespace duckparser {
                 ignore_delay = true;
             }
             // LED
-#if !defined(LED_DISABLED)
+#if !defined(LED_SCRIPTING_CONTROL_DISABLED)
             else if (compare(cmd->str, cmd->len, "LED", CASE_SENSETIVE)) {
                 // i.e. LED R SOLID
                 if (wl->size == 3) {

--- a/src/led/led.cpp
+++ b/src/led/led.cpp
@@ -21,9 +21,7 @@ namespace led {
 
     void change_color(int r, int g, int b) {
 #if defined(LED_SIMPLE)
-        if (enabled) {
-            digitalWrite(LED_PIN, (r+g+b));
-        }
+        return;
 #else
         if (LED_PIN < 0) return;
 
@@ -49,8 +47,11 @@ namespace led {
 
     void setEnable(bool _enabled) {
 #ifdef LED_SIMPLE
-        if (!_enabled) {
-            enabled = _enabled;
+        enabled = _enabled;
+        if (_enabled) {
+            digitalWrite(LED_PIN, 1);
+        }
+        else {
             digitalWrite(LED_PIN, 0);
         }
 #else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,15 @@ void setup() {
     // Start Serial (for debug) or disable it
     debug_init();
 
+#ifdef USE_CUSTOM_SPI_PINOUT    
+    // Setup SPI with custom pinout
+    SPI1.setSCK(SD_PIN_SCK);
+    SPI1.setTX(SD_PIN_MOSI);
+    SPI1.setRX(SD_PIN_MISO);
+    SPI1.setCS(SD_PIN_CS);
+    SPI1.begin();
+#endif
+
     // Initialize memory and check for problems
     bool msc_ok = msc::init();
     if (!msc_ok) {
@@ -45,6 +54,7 @@ void setup() {
     } else {
         // msc unavailable: keep defaults in preferences
     }
+
     if (selector::mode() == SETUP) preferences::save();
 
 #ifdef MULTI_SELECTOR
@@ -76,10 +86,16 @@ void setup() {
         msc::enableDrive();
     }
 
-    // LED settings
-    led::setEnable(preferences::ledEnabled());
+    #if !defined(LED_SIMPLE)
+        // Enable LED instantly if RGB LED
+        led::setEnable(preferences::ledEnabled());;
+    #endif
 
     if (selector::mode() == SETUP) {
+        #if defined(LED_SIMPLE)
+            // Simple LED is always on in setup mode if enabled
+            led::setEnable(preferences::ledEnabled());;
+        #endif
         led::setColor(preferences::getSetupColor());
     } else {
         led::setColor(preferences::getAttackColor());
@@ -127,9 +143,18 @@ void setup() {
 
     // Start attack
     if ((selector::mode() == ATTACK) && !preferences::getRunOnIndicator()) {
-        delay(preferences::getInitialDelay());      // Wait to give computer time to init keyboard
-        attack::start();                            // Start keystroke injection attack
-        led::setColor(preferences::getIdleColor()); // Set LED to green
+        delay(preferences::getInitialDelay()); // Wait to give computer time to init keyboard
+        #if defined(LED_SIMPLE)
+            // If Simple LED is enabled turn it on for duration of attack
+            led::setEnable(preferences::ledEnabled());
+        #endif
+        attack::start(); // Start keystroke injection attack
+        #if defined(LED_SIMPLE)
+            // Disable Simple LED after attack
+            led::setEnable(false);
+        #else
+            led::setColor(preferences::getIdleColor()); // Set LED to green
+        #endif
     }
 
     // Setup CLI

--- a/src/msc/format_sd.cpp
+++ b/src/msc/format_sd.cpp
@@ -2,6 +2,7 @@
 
 #include "format.h"
 
+#include "spiconf.h"
 #include "config.h"
 #include "debug.h"
 
@@ -19,18 +20,6 @@
  */
 #include <SdFat.h>
 #include <sdios.h>
-
-// Try max SPI clock for an SD. Reduce SPI_CLOCK if errors occur.
-#define SPI_CLOCK SD_SCK_MHZ(12)
-
-// Try to select the best SD card configuration.
-#if HAS_SDIO_CLASS
-#define SD_CONFIG SdioConfig(FIFO_SDIO)
-#elif  ENABLE_DEDICATED_SPI
-#define SD_CONFIG SdSpiConfig(SD_CS, DEDICATED_SPI, SPI_CLOCK)
-#else  // HAS_SDIO_CLASS
-#define SD_CONFIG SdSpiConfig(SD_CS, SHARED_SPI, SPI_CLOCK)
-#endif  // HAS_SDIO_CLASS
 
 namespace format {
     // ========== PRIVATE ========= //

--- a/src/msc/msc_sd.cpp
+++ b/src/msc/msc_sd.cpp
@@ -2,6 +2,7 @@
 
 #include "msc.h"
 
+#include "spiconf.h"
 #include "config.h"
 #include "debug.h"
 #include "format.h"
@@ -76,7 +77,7 @@ namespace msc {
 
     // ===== PUBLIC ===== //
     bool init() {
-        if (!sd.begin(SD_CS, SD_SCK_MHZ(12))) {
+        if (!sd.begin(SD_CONFIG)) {
             debugln("Couldn't init SD Card!");
             return false;
         }

--- a/src/msc/spiconf.h
+++ b/src/msc/spiconf.h
@@ -1,0 +1,21 @@
+// Try max SPI clock for an SD. Reduce SPI_CLOCK if errors occur.
+#define SPI_CLOCK SD_SCK_MHZ(15)
+
+#include <SdFat.h>
+
+#if USE_CUSTOM_SPI_PINOUT
+    #if  ENABLE_DEDICATED_SPI
+        #define SD_CONFIG SdSpiConfig(SD_PIN_CS, DEDICATED_SPI, SPI_CLOCK, &SPI1)
+    #else
+        #define SD_CONFIG SdSpiConfig(SD_PIN_CS, SHARED_SPI, SPI_CLOCK, &SPI1)
+    #endif
+#else
+    // Try to select the best SD card configuration.
+    #if defined(HAS_SDIO_CLASS) && defined(SDIO_USE_PIO)
+        #define SD_CONFIG SdioConfig(FIFO_SDIO)
+    #elif  ENABLE_DEDICATED_SPI
+        #define SD_CONFIG SdSpiConfig(SD_PIN_CS, DEDICATED_SPI, SPI_CLOCK)
+    #else 
+        #define SD_CONFIG SdSpiConfig(SD_PIN_CS, SHARED_SPI, SPI_CLOCK)
+    #endif
+#endif


### PR DESCRIPTION
I was having issues with the default MalDuino 3 firmware and found this repository which supports the older MalDuino 2. Spent the whole day figuring out the pin layout with some trial and error by reading the traces on the board. Finally got it to work like I wanted and thought I'd contribute.

Added a new board config. Not sure about the name "MalDuino 3 (RP2040, 16MB)" because I couldn't find the memory chips spec anywhere on the web. So I configured it as 16MB. The Malduino 3 also has another flash chip which is used as storage for the scripts and exfiltrating files. That chip is 128MB as per the store page.

Added ability to map custom GPIO pins on SPI1 so that the MalDuino 3 128MB flash chip mounts correctly.

Renamed some flags for clarity.

Fixed a typo.

Added alias for CHARACTER_DELAY as CHAR_DELAY to fit the documentation.

Adjusted how the "Simple" LED works on the MalDuino. Now setting the color wont change the state of the LED. The LED is controlled setEnable only. I did this because the LED didn't work at all with the old code in (in v1.2.3).

For spiconf.h Im unsure if this is the correct way to do it and if it doesn't affect the other supported boards. I'm primarily worried about SdioConfig(FIFO_SDIO) cause it caused issues for me when trying to compile the project with the old flag (check in v1.2.3). To avoid issues I added an extra check for SDIO_USE_PIO but I can't test this on relevant boards.

Bumped SD_SCK_MHZ from 12 to 15.

If this is going to be merged then the version number should be updated too.

I tested this on my own MalDuino 3 and it seemed to be working fine. Can't test other boards.

Also consider using platform = https://github.com/maxgerhardt/platform-raspberrypi.git instead of platform = raspberrypi. I couldn't build the firmware for usbnova_mkii with the short version.